### PR TITLE
Fix eraser

### DIFF
--- a/src/Editor.vue
+++ b/src/Editor.vue
@@ -114,6 +114,7 @@
                 this.cancelCroppingImage()
             },
             set(type, params) {
+                this.canvas.off('mouse:down');
                 switch (type) {
                     case "text":
                         this.currentActiveTool = type;
@@ -262,7 +263,6 @@
                         new CropImage(this.canvas, true, false, false, this.params);
                         break;
                     case 'eraser':
-                        this.canvas.off('mouse:down');
                         this.currentActiveTool = type;
                         let inst = this;
                         this.canvas.isDrawingMode = false;


### PR DESCRIPTION
The `mouse:down` event is not being removed after eraser is selected, causing items to be deleted after other tools are selected. This PR removes the event on each `set()` call,  since it is being recreated by fabric anyway.